### PR TITLE
Better TypeScript types

### DIFF
--- a/npm/index.d.ts
+++ b/npm/index.d.ts
@@ -38,7 +38,7 @@ type ColorSpacePreset =
   | "purple-wine"
 type ColorSpace = ColorSpacePreset | ColorSpaceArray | ColorSpaceObject;
 
-type IWantHueOptions = {
+interface IWantHueOptions {
   colorFilter?: ColorFilterFunction,
   colorSpace?: ColorSpace,
   clustering?: 'k-means' | 'force-vector',
@@ -46,6 +46,6 @@ type IWantHueOptions = {
   ultraPrecision?: boolean,
   distance?: 'euclidean' | 'cmc' | 'compromise' | 'protanope' | 'deuteranope' | 'tritanope',
   seed?: string | null
-};
+}
 
 export default function iwanthue(colors: number, options?: IWantHueOptions): Array<string>;

--- a/npm/index.d.ts
+++ b/npm/index.d.ts
@@ -11,7 +11,32 @@ type ColorSpaceObject = {
   lmin?: number,
   lmax?: number
 };
-type ColorSpace = string | ColorSpaceArray | ColorSpaceObject;
+
+/**
+ * Available color spaces
+ * @see https://github.com/medialab/iwanthue/blob/master/npm/presets.js
+ */
+type ColorSpacePreset =
+  | "all"
+  | "default"
+  | "colorblind"
+  | "fancy-light"
+  | "fancy-dark"
+  | "shades"
+  | "tarnish"
+  | "pastel"
+  | "pimp"
+  | "intense"
+  | "fluo"
+  | "red-roses"
+  | "ochre-sand"
+  | "yellow-lime"
+  | "green-mint"
+  | "ice-cube"
+  | "blue-ocean"
+  | "indigo-night"
+  | "purple-wine"
+type ColorSpace = ColorSpacePreset | ColorSpaceArray | ColorSpaceObject;
 
 type IWantHueOptions = {
   colorFilter?: ColorFilterFunction,


### PR DESCRIPTION
Add better support for TypeScript types:
1. Add string literal for presets.
2. Fix the type of `IWantHueOptions`.

This should be included as a patch version ideally, or a breaking one - if you consider invalid types that were allowed before past compile-time (which I don't). e.g. [this](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBMA7gQwHYwBYFcCmcBmUEIcA5EmprqQNwBQdAxhKgM7zMA20rcAvAhTpsOABQAmADRwA3nThwA9IrgAVDMF6a4EAEYA3YBCytOATwSpmUKDkbxk8KFnSgc03VnhhkrVjl5mcGBOHABaGDd5OC5oAGUfRhwALjJgVH1kTmAAE1JJBgVlOABBTk4dfDhMALxkWzhbAEcsYFscuF0LGDMwPBycfHTgSJZeGAgc5DNoxk4TGBwodIBzVNIAazCQHDRWfOiczRg0JPXGEEYDhVioADEQxahU0QBKfgA+aud3aJaskZmVIARgKCn8OByqVQWHKYLgsJgUGQAAVbIxNEZUKl8Fl-HQAL6vIA) works in v1.4.0:
```ts
import iwanthue from 'iwanthue';

const colors = iwanthue(2, {
  // This is obviously incorrect at runtime, but passes compile-time
  colorSpace: 'invalid',

  // All of these are required by type definitions today
  clustering: 'k-means',
  distance: 'cmc',
  colorFilter: () => true,
  quality: 1,
  seed: null,
  ultraPrecision: false
})
```

Following this change you'd get an error on line 5 (`colorSpace: 'invalid'`) and would be able to omit the rest of the options.