### PR TITLE
optimize runtime for large input

### DIFF
--- a/npm/helpers.js
+++ b/npm/helpers.js
@@ -135,34 +135,68 @@ function labToHcl(lab) {
 }
 
 function diffSort(distance, colors) {
+  const colorsCount = colors.length;
   colors = colors.slice();
 
-  var diffColors = [colors.shift()];
+  var cachedDistances = new Array();
 
-  var index, maxDistance, candidateIndex;
+  var diffColors = [colors[0]];
+  colors[0] = null;
 
-  var A, B, d, i;
+  while (diffColors.length < colorsCount) {
 
-  while (colors.length > 0) {
-    index = -1;
-    maxDistance = -Infinity;
+    var lastPickColor = diffColors[diffColors.length - 1];
+    var lastDistances = [];
 
-    for (candidateIndex = 0; candidateIndex < colors.length; candidateIndex++) {
-      A = colors[candidateIndex];
+    colors.forEach((color,idx)=>{
+      if(color){
+        lastDistances.push([distance(lastPickColor, color),idx]);
+      }
+    });
 
-      for (i = 0; i < diffColors.length; i++) {
-        B = diffColors[i];
-        d = distance(A, B);
+    lastDistances.sort((a,b)=>{
+      if(a[0] == b[0]){
+        return 0;
+      }
+      return a[0] < b[0]?-1:1;
+    });
 
-        if (d > maxDistance) {
-          maxDistance = d;
-          index = candidateIndex;
+    cachedDistances.push(lastDistances);
+
+    var maxDistance = -Infinity;
+    var toPickIdx = -1;
+
+
+
+    for(var j = 0; j< cachedDistances.length;++j)
+    {
+      var distances = cachedDistances[j];
+      if(distances.length == 0){
+        continue;
+      }
+
+      for(var i = 0;i < distances.length;){
+
+        var reverseIdx = distances.length - 1 - i;
+        var thisIdx = distances[reverseIdx][1];
+        if(colors[thisIdx] == null){
+          // already being picked
+          distances.pop();
+          continue;
         }
+
+        var thisDistance = distances[reverseIdx][0];
+        if(thisDistance > maxDistance){
+          maxDistance = thisDistance;
+          toPickIdx = thisIdx;
+        }
+
+        break;
       }
     }
 
-    diffColors.push(colors[index]);
-    colors.splice(index, 1);
+    diffColors.push(colors[toPickIdx]);
+    colors[toPickIdx] = null;
   }
 
   return diffColors;

--- a/npm/helpers.js
+++ b/npm/helpers.js
@@ -145,48 +145,44 @@ function diffSort(distance, colors) {
 
   while (diffColors.length < colorsCount) {
 
-    var lastPickColor = diffColors[diffColors.length - 1];
-    var lastDistances = [];
+    const lastPickColor = diffColors[diffColors.length - 1];
+    const lastDistances = [];
 
-    colors.forEach((color,idx)=>{
-      if(color){
-        lastDistances.push([distance(lastPickColor, color),idx]);
+    colors.forEach((color, idx)=>{
+      if (color) {
+        lastDistances.push([distance(lastPickColor, color), idx]);
       }
     });
-
-    lastDistances.sort((a,b)=>{
-      if(a[0] == b[0]){
+    lastDistances.sort((a, b)=>{
+      if (a[0] === b[0]) {
         return 0;
       }
-      return a[0] < b[0]?-1:1;
+      return a[0] < b[0] ? -1 : 1;
     });
-
     cachedDistances.push(lastDistances);
 
     var maxDistance = -Infinity;
     var toPickIdx = -1;
 
-
-
-    for(var j = 0; j< cachedDistances.length;++j)
+    for (var j = 0; j < cachedDistances.length; ++j)
     {
       var distances = cachedDistances[j];
-      if(distances.length == 0){
+      if (distances.length === 0) {
         continue;
       }
 
-      for(var i = 0;i < distances.length;){
+      for (var i = 0; i < distances.length;) {
 
         var reverseIdx = distances.length - 1 - i;
         var thisIdx = distances[reverseIdx][1];
-        if(colors[thisIdx] == null){
+        if (colors[thisIdx] === null) {
           // already being picked
           distances.pop();
           continue;
         }
 
         var thisDistance = distances[reverseIdx][0];
-        if(thisDistance > maxDistance){
+        if (thisDistance > maxDistance) {
           maxDistance = thisDistance;
           toPickIdx = thisIdx;
         }


### PR DESCRIPTION
I find that iwanthue spend more than 30 seconds if a large input given (3000),  
due to diffSort slowness. this PR improve it by:  

1. avoid duplicate distance calucation during every pick-up
2. sort the distance to make max element search done in O(n)

benchmark (time in ms) shows:
count,pr,origin
128,2,2
256,4,17
512,16,139
1024,75,1129
2048,366,9530
4096,1677,77745

<img width="1092" height="360" alt="image" src="https://github.com/user-attachments/assets/9152f71a-b296-49dd-8cad-279d0e308314" />

as we can see, runtime decrease from cubic to quadratic

note: result might not 100% exactly same as original implementation, due to different compare order when two pair of points give exactly same distance.