### PR TITLE
Expand palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ var palette = iwanthue(5, {
   * **ultraPrecision** *?boolean* [`false`]: Ultra precision for `k-means` colorspace sampling?
   * **distance** *?string* [`euclidean`]: Distance function to use. Can be `euclidean`, `cmc`, `compromise` (colorblind), `protanope`, `deuteranope` or `tritanope`.
   * **seed** *?string|number*: Random number generator seed. Useful to produce the same palette every time based on some data attribute.
+  * **originalColorsToExpand** *?string[]*: list of colors (existing palette) to expand by adding new colors. if no colorSpace in settings, the smallest preset which contains all given colors will be used
 
 ### Palette
 

--- a/npm/helpers.d.ts
+++ b/npm/helpers.d.ts
@@ -1,0 +1,4 @@
+export function rgbHexToLab(hex: string): [number, number, number];
+export function labToHcl(
+  hcl: [number, number, number],
+): [number, number, number];

--- a/npm/helpers.d.ts
+++ b/npm/helpers.d.ts
@@ -1,4 +1,9 @@
+import { ColorSpacePreset } from ".";
+
 export function rgbHexToLab(hex: string): [number, number, number];
 export function labToHcl(
   hcl: [number, number, number],
 ): [number, number, number];
+export function detectSmallestCompatibleColorSpace(
+  hexColors: string[],
+): ColorSpacePreset | undefined;

--- a/npm/helpers.js
+++ b/npm/helpers.js
@@ -256,3 +256,4 @@ exports.labToHcl = labToHcl;
 exports.diffSort = diffSort;
 exports.computeQualityMetrics = computeQualityMetrics;
 exports.detectSmallestCompatibleColorSpace = detectSmallestCompatibleColorSpace;
+exports.colorSpacePresetsSortedByArea = colorSpacePresetsSortedByArea;

--- a/npm/helpers.js
+++ b/npm/helpers.js
@@ -95,6 +95,11 @@ function rgbToLab(rgb) {
   return [l < 0 ? 0 : l, 500 * (x - y), 200 * (y - z)];
 }
 
+function validateRgbHex(rgbHex) {
+  var rgbHexRegExp = new RegExp('^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$');
+  return rgbHexRegExp.test(rgbHex);
+}
+
 function validateRgb(rgb) {
   var r = rgb[0];
   var g = rgb[1];
@@ -116,6 +121,14 @@ function labToRgbHex(lab) {
     hexPad(rgb[1]) +
     hexPad(rgb[2])
   );
+}
+
+function rgbHexToLab(hex) {
+  return rgbToLab([
+    parseInt(hex.slice(1, 3), 16),
+    parseInt(hex.slice(3, 5), 16),
+    parseInt(hex.slice(5, 7), 16)
+  ]);
 }
 
 var RAD_TO_DEG = 180 / Math.PI;
@@ -191,8 +204,10 @@ function computeQualityMetrics(distance, colors) {
 }
 
 exports.validateRgb = validateRgb;
+exports.validateRgbHex = validateRgbHex;
 exports.labToRgb = labToRgb;
 exports.labToRgbHex = labToRgbHex;
+exports.rgbHexToLab = rgbHexToLab;
 exports.rgbToLab = rgbToLab;
 exports.labToHcl = labToHcl;
 exports.diffSort = diffSort;

--- a/npm/helpers.js
+++ b/npm/helpers.js
@@ -1,5 +1,4 @@
-var {sortBy, toPairs} = require('lodash');
-const presets = require('./presets');
+var presets = require('./presets');
 
 /**
  * Iwanthue Library Helpers
@@ -206,11 +205,11 @@ function computeQualityMetrics(distance, colors) {
   return {min: min, mean: S / t};
 }
 
-var colorSpacePresetsAreas = sortBy(
-  toPairs(presets).map(([presetKey, preset]) => {
+var colorSpacePresetsAreas = Object.keys(presets).map((presetKey) => {
+    var preset = presets[presetKey];
     // hRange can be expressed as a range from 330 to 360 and from 0 to 20 as [330, 20]
     // in that case the range has to be calculated differently
-    const hRange =
+    var hRange =
       preset[1] >= preset[0]
         ? preset[1] - preset[0]
         : 360 - preset[0] + preset[1];
@@ -218,8 +217,7 @@ var colorSpacePresetsAreas = sortBy(
       key: presetKey,
       area: hRange * (preset[3] - preset[2]) * (preset[5] - preset[4]),
     };
-  }),
-  function ({area}) {return area;});
+  }).sort(function (a, b) {return a.area - b.area;});
 
 var colorSpacePresetsSortedByArea = colorSpacePresetsAreas.map(
   function ({key}) {return key;});

--- a/npm/helpers.js
+++ b/npm/helpers.js
@@ -1,3 +1,6 @@
+var {sortBy, toPairs} = require('lodash');
+const presets = require('./presets');
+
 /**
  * Iwanthue Library Helpers
  * =========================
@@ -203,6 +206,46 @@ function computeQualityMetrics(distance, colors) {
   return {min: min, mean: S / t};
 }
 
+var colorSpacePresetsAreas = sortBy(
+  toPairs(presets).map(([presetKey, preset]) => {
+    // hRange can be expressed as a range from 330 to 360 and from 0 to 20 as [330, 20]
+    // in that case the range has to be calculated differently
+    const hRange =
+      preset[1] >= preset[0]
+        ? preset[1] - preset[0]
+        : 360 - preset[0] + preset[1];
+    return {
+      key: presetKey,
+      area: hRange * (preset[3] - preset[2]) * (preset[5] - preset[4]),
+    };
+  }),
+  function ({area}) {return area;});
+
+var colorSpacePresetsSortedByArea = colorSpacePresetsAreas.map(
+  function ({key}) {return key;});
+
+function detectSmallestCompatibleColorSpace(hexColors) {
+  var colorSpace = colorSpacePresetsSortedByArea.find((presetKey) => {
+    // test that all colors are include din the color area
+    var areaBounds = presets[presetKey];
+    return hexColors
+      .map(function (c) { return labToHcl(rgbHexToLab(c));})
+      .every(
+        function ([h, c, l]) {
+          return (areaBounds[0] <= areaBounds[1]
+            ? areaBounds[0] <= h && h <= areaBounds[1]
+            : areaBounds[0] <= h || h <= areaBounds[1]) &&
+          areaBounds[2] <= c &&
+          c <= areaBounds[3] &&
+          areaBounds[4] <= l &&
+          l <= areaBounds[5];
+        }
+      );
+  });
+
+  return colorSpace;
+}
+
 exports.validateRgb = validateRgb;
 exports.validateRgbHex = validateRgbHex;
 exports.labToRgb = labToRgb;
@@ -212,3 +255,4 @@ exports.rgbToLab = rgbToLab;
 exports.labToHcl = labToHcl;
 exports.diffSort = diffSort;
 exports.computeQualityMetrics = computeQualityMetrics;
+exports.detectSmallestCompatibleColorSpace = detectSmallestCompatibleColorSpace;

--- a/npm/index.d.ts
+++ b/npm/index.d.ts
@@ -67,7 +67,9 @@ export interface IWantHueSettings {
   quality?: number,
   ultraPrecision?: boolean,
   distance?: Distance,
-  seed?: string | number | null
+  seed?: string | number | null,
+  // list of hexadecimal colors which will be expanded with more colours (up to count)
+  originalColorsToExpand?: string[]
 }
 
 export default function iwanthue(count: number, settings?: IWantHueSettings): Array<string>;

--- a/npm/index.js
+++ b/npm/index.js
@@ -89,6 +89,11 @@ function resolveAndValidateSettings(userSettings) {
     })))
     throw new Error(`iwanthue: invalid 'originalColorsToExpand' ${settings.originalColorsToExpand}. Expecting an array of hexadecimal colors.`);
 
+
+  if (settings.originalColorsToExpand !== null && settings.originalColorsToExpand.length > 0 && settings.colorSpace === 'default') {
+    settings.colorSpace = helpers.detectSmallestCompatibleColorSpace(settings.originalColorsToExpand);
+  }
+
   // Building color filter from preset?
   if (!settings.colorFilter) {
     if (
@@ -517,8 +522,6 @@ module.exports = function generatePalette(count, settings) {
 
   if (settings.originalColorsToExpand) {
       //Correct palette by taking into account original colors
-      // var expandSettings = settings;
-      // expandSettings.quality = 50;
 
       kMeans(distances.get('euclidean'), validColor, colors, settings);
   }

--- a/npm/index.js
+++ b/npm/index.js
@@ -8,6 +8,7 @@ var Random = require('./rng.js');
 var CachedDistances = require('./distances.js');
 var helpers = require('./helpers.js');
 var presets = require('./presets.js');
+const {omit} = require('lodash');
 
 var validateRgb = helpers.validateRgb;
 var labToRgb = helpers.labToRgb;
@@ -20,6 +21,7 @@ var diffSort = helpers.diffSort;
  */
 var DEFAULT_SETTINGS = {
   attempts: 1,
+  originalColorsToExpand: null,
   colorFilter: null,
   colorSpace: 'default',
   clustering: 'k-means',
@@ -80,6 +82,12 @@ function resolveAndValidateSettings(userSettings) {
 
   if (settings.seed !== null && typeof settings.seed !== 'number')
     throw new Error('iwanthue: invalid `seed`. Expecting an integer or a string.');
+  if (settings.originalColorsToExpand !== null && (
+    !Array.isArray(settings.originalColorsToExpand) ||
+    !settings.originalColorsToExpand.every(function(c) {
+      return typeof c === 'string' && helpers.validateRgbHex(c);
+    })))
+    throw new Error(`iwanthue: invalid 'originalColorsToExpand' ${settings.originalColorsToExpand}. Expecting an array of hexadecimal colors.`);
 
   // Building color filter from preset?
   if (!settings.colorFilter) {
@@ -246,13 +254,25 @@ function forceVector(rng, distance, validColor, colors, settings) {
 }
 
 function kMeans(distance, validColor, colors, settings) {
+  // discretized color space into list of colors
   var colorSamples = [];
+  // for each color sample indicate the index in the colors array of the closest color
   var samplesClosest = [];
+  var lockMaxIndex = -1;
+  if (settings.originalColorsToExpand) {
+    // replace sampled colors by original ones
+    diffSort(distance, settings.originalColorsToExpand.map(helpers.rgbHexToLab)).forEach(function (c, i) {
+      colors[i] = c;
+    });
 
+    lockMaxIndex = settings.originalColorsToExpand.length - 1;
+
+  }
   var l, a, b;
 
   var lab, rgb;
 
+  // Define sample discretization precision: i.e. number of samples
   var linc = 5,
       ainc = 10,
       binc = 10;
@@ -263,6 +283,7 @@ function kMeans(distance, validColor, colors, settings) {
     binc = 5;
   }
 
+  // sample the color space
   for (l = 0; l <= 100; l += linc) {
     for (a = -100; a <= 100; a += ainc) {
       for (b = -100; b <= 100; b += binc) {
@@ -273,6 +294,7 @@ function kMeans(distance, validColor, colors, settings) {
           continue;
 
         colorSamples.push(lab);
+        // prepare closest array fin expanding it to the same size as samples
         samplesClosest.push(null);
       }
     }
@@ -289,11 +311,12 @@ function kMeans(distance, validColor, colors, settings) {
       lj = colors.length;
 
 
-  var d, minDistance, freeColorSamples, count, candidate, closest;
+  var d, minDistance, freeColorSamples, nbCandidates, candidate, closest;
 
+  // multiple pass on the same algo
   while (steps-- > 0) {
 
-    // Finding closest color
+    // For each sample, find the closest color
     for (i = 0; i < li; i++) {
       B = colorSamples[i];
       minDistance = Infinity;
@@ -305,34 +328,47 @@ function kMeans(distance, validColor, colors, settings) {
 
         if (d < minDistance) {
           minDistance = d;
+          // store closest color index
           samplesClosest[i] = j;
         }
       }
     }
 
+    // copy samples
     freeColorSamples = colorSamples.slice();
 
+    // For each color
     for (j = 0; j < lj; j++) {
-      count = 0;
+
+      nbCandidates = 0;
       candidate = [0, 0, 0];
 
+      // for each sample
       for (i = 0; i < li; i++) {
+        // if sample closest color is the current color
         if (samplesClosest[i] === j) {
-          count++;
-          candidate[0] += colorSamples[i][0];
-          candidate[1] += colorSamples[i][1];
-          candidate[2] += colorSamples[i][2];
+          nbCandidates++;
+          // sum each color component of all candidates
+          candidate[0] += colorSamples[i][0]; // l
+          candidate[1] += colorSamples[i][1]; // a
+          candidate[2] += colorSamples[i][2]; // b
         }
       }
 
-      if (count !== 0) {
-        candidate[0] /= count;
-        candidate[1] /= count;
-        candidate[2] /= count;
+      if (nbCandidates !== 0) {
+        // average the candidate color components
+        candidate[0] /= nbCandidates;
+        candidate[1] /= nbCandidates;
+        candidate[2] /= nbCandidates;
+      } else {
+        candidate = colors[j];
+      }
 
-        rgb = labToRgb(candidate);
-
-        if (validColor(rgb, candidate)) {
+      rgb = labToRgb(candidate);
+      // We adjust color using kmeans only for colors not locked ie provided as original to expand
+      if (j > lockMaxIndex) {
+        if (nbCandidates !== 0 && validColor(rgb, candidate)) {
+          // pick the candidate
           colors[j] = candidate;
         }
         else {
@@ -373,18 +409,19 @@ function kMeans(distance, validColor, colors, settings) {
             colors[j] = colorSamples[closest];
           }
 
-          // Cleaning up free samples
-          /* eslint-disable */
-          freeColorSamples = freeColorSamples.filter(function(color) {
-            return (
-              color[0] !== colors[j][0] ||
-              color[1] !== colors[j][1] ||
-              color[2] !== colors[j][2]
-            )
-          });
-          /* eslint-enable */
         }
       }
+      // Cleaning up free samples from chosen colors
+      /* eslint-disable */
+      freeColorSamples = freeColorSamples.filter(function(color) {
+        return (
+          color[0] !== colors[j][0] ||
+          color[1] !== colors[j][1] ||
+          color[2] !== colors[j][2]
+        )
+      });
+      /* eslint-enable */
+
     }
   }
 
@@ -402,11 +439,17 @@ function kMeans(distance, validColor, colors, settings) {
  * @param  {boolean}    ultraPrecision   - Whether to use ultra precision or not.
  * @param  {string}     distance         - Name of the color distance function to use. Defaults to 'colorblind'.
  * @param  {number}     seed             - Seed for random number generation.
+ * @param {Array[string]} originalColorsToExpand - List of hexadecimal colors from which to build the palette
  * @return {Array}                     - The computed palette as an array of hexadecimal colors.
  */
 module.exports = function generatePalette(count, settings) {
   if (typeof count !== 'number' || count < 1)
     throw new Error('iwanthue: expecting a color count > 1.');
+
+  if (settings.originalColorsToExpand && settings.originalColorsToExpand.length >= count) {
+    // original colors settings is long enough to generate the requested colors palette.
+    return settings.originalColorsToExpand.slice(0, count);
+  }
 
   settings = resolveAndValidateSettings(settings);
 
@@ -455,9 +498,10 @@ module.exports = function generatePalette(count, settings) {
     colors = sampleLabColors(rng, count, validColor);
 
     if (settings.clustering === 'force-vector')
-      forceVector(rng, distance, validColor, colors, settings);
+      forceVector(rng, distance, validColor, colors, omit(settings, ['originalColorsToExpand']));
     else
-      kMeans(distance, validColor, colors, settings);
+      kMeans(distance, validColor, colors, omit(settings, ['originalColorsToExpand']));
+
 
     metrics = helpers.computeQualityMetrics(distance, colors);
 
@@ -468,9 +512,16 @@ module.exports = function generatePalette(count, settings) {
 
     attempts--;
   }
-
   colors = best;
   colors = diffSort(distance, colors);
+
+  if (settings.originalColorsToExpand) {
+      //Correct palette by taking into account original colors
+      // var expandSettings = settings;
+      // expandSettings.quality = 50;
+
+      kMeans(distances.get('euclidean'), validColor, colors, settings);
+  }
 
   return colors.map(labToRgbHex);
 };

--- a/npm/index.js
+++ b/npm/index.js
@@ -90,7 +90,7 @@ function resolveAndValidateSettings(userSettings) {
     throw new Error(`iwanthue: invalid 'originalColorsToExpand' ${settings.originalColorsToExpand}. Expecting an array of hexadecimal colors.`);
 
 
-  if (settings.originalColorsToExpand !== null && settings.originalColorsToExpand.length > 0 && settings.colorSpace === 'default') {
+  if (settings.originalColorsToExpand !== null && settings.originalColorsToExpand.length > 0 && !userSettings.colorSpace) {
     settings.colorSpace = helpers.detectSmallestCompatibleColorSpace(settings.originalColorsToExpand);
   }
 

--- a/npm/index.js
+++ b/npm/index.js
@@ -8,7 +8,6 @@ var Random = require('./rng.js');
 var CachedDistances = require('./distances.js');
 var helpers = require('./helpers.js');
 var presets = require('./presets.js');
-const {omit} = require('lodash');
 
 var validateRgb = helpers.validateRgb;
 var labToRgb = helpers.labToRgb;
@@ -499,13 +498,16 @@ module.exports = function generatePalette(count, settings) {
   var bestMetric = -Infinity,
       best;
 
+  var settingsWithoutOriginalColorsToExpand = settings.originalColorsToExpand ? Object.keys(settings).filter(function(k) { return k !== 'originalColorsToExpand'; }).reduce(function (o, k) {
+    o[k] = settings[k];
+    return o;
+  }, {}) : settings;
   while (attempts > 0) {
     colors = sampleLabColors(rng, count, validColor);
-
     if (settings.clustering === 'force-vector')
-      forceVector(rng, distance, validColor, colors, omit(settings, ['originalColorsToExpand']));
+      forceVector(rng, distance, validColor, colors, settingsWithoutOriginalColorsToExpand);
     else
-      kMeans(distance, validColor, colors, omit(settings, ['originalColorsToExpand']));
+      kMeans(distance, validColor, colors, settingsWithoutOriginalColorsToExpand);
 
 
     metrics = helpers.computeQualityMetrics(distance, colors);

--- a/npm/palette.js
+++ b/npm/palette.js
@@ -45,7 +45,7 @@ Palette.prototype.toJSON = function() {
 };
 
 Palette.fromJSON = function(data) {
-  const map = new Map(data.entries);
+  var map = new Map(data.entries);
 
   return new Palette(data.name, map, data.defaultColor);
 };
@@ -75,7 +75,7 @@ Palette.generateFromValues = function(name, values, settings) {
 };
 
 Palette.fromEntries = function(name, entries, defaultColor) {
-  const map = new Map();
+  var map = new Map();
 
   forEach(entries, function(entry) {
     map.set(entry[0], entry[1]);
@@ -85,7 +85,7 @@ Palette.fromEntries = function(name, entries, defaultColor) {
 };
 
 Palette.fromMapping = function(name, mapping, defaultColor) {
-  const map = new Map();
+  var map = new Map();
 
   forEach(mapping, function(color, value) {
     map.set(value, color);

--- a/npm/presets.d.ts
+++ b/npm/presets.d.ts
@@ -1,4 +1,4 @@
-import { ColorSpaceArray } from ".";
+import { ColorSpaceArray, ColorSpacePreset } from ".";
 
 declare const presets: Record<ColorSpacePreset, ColorSpaceArray>;
 export default presets;

--- a/npm/presets.d.ts
+++ b/npm/presets.d.ts
@@ -1,0 +1,4 @@
+import { ColorSpaceArray } from ".";
+
+declare const presets: Record<ColorSpacePreset, ColorSpaceArray>;
+export default presets;

--- a/npm/test/helpers.js
+++ b/npm/test/helpers.js
@@ -53,4 +53,20 @@ describe('helpers', function() {
 
     assert.deepEqual(output, sortedColors);
   });
+
+  it('should be possible to find the smallest preset matching a palette', function () {
+    var shades = ['#c6ccc2', '#2f251b', '#858a84', '#294240', '#655b4c'];
+    assert.strictEqual(helpers.detectSmallestCompatibleColorSpace(shades), 'shades');
+
+    // expected result: we find the smallest preset, fancy-light and pastels share lots of common colors,
+    // fancy being smallest it's picked up in this case
+    var pastels = ['#e6b8b3', '#a7dde2', '#d1bbdf', '#d4d9b6', '#aac4e2', '#9bc2af'];
+    assert.strictEqual(helpers.detectSmallestCompatibleColorSpace(pastels), 'fancy-light');
+
+    var ochreSand = ['#946056', '#e99478', '#995432', '#d79d91', '#b65f56'];
+    assert.strictEqual(helpers.detectSmallestCompatibleColorSpace(ochreSand), 'ochre-sand');
+
+    var intense = ['#749a50', '#6b47b8', '#c76c3f', '#cd53b8', '#6f86b5', '#a04a61'];
+    assert.strictEqual(helpers.detectSmallestCompatibleColorSpace(intense), 'intense');
+  });
 });

--- a/npm/test/helpers.js
+++ b/npm/test/helpers.js
@@ -1,7 +1,7 @@
 var assert = require('chai').assert;
 var helpers = require('../helpers.js');
 var CachedDistances = require('../distances.js');
-const {colorSpacePresetsSortedByArea} = require('../helpers.js');
+var {colorSpacePresetsSortedByArea} = require('../helpers.js');
 
 var LAB_COLORS = [
   [45.19047619047619, 42.698412698412696, 17.142857142857142],

--- a/npm/test/helpers.js
+++ b/npm/test/helpers.js
@@ -1,6 +1,7 @@
 var assert = require('chai').assert;
 var helpers = require('../helpers.js');
 var CachedDistances = require('../distances.js');
+const {colorSpacePresetsSortedByArea} = require('../helpers.js');
 
 var LAB_COLORS = [
   [45.19047619047619, 42.698412698412696, 17.142857142857142],
@@ -68,5 +69,30 @@ describe('helpers', function() {
 
     var intense = ['#749a50', '#6b47b8', '#c76c3f', '#cd53b8', '#6f86b5', '#a04a61'];
     assert.strictEqual(helpers.detectSmallestCompatibleColorSpace(intense), 'intense');
+  });
+
+  it('should properly sort preset by size', () => {
+    assert.sameOrderedMembers(colorSpacePresetsSortedByArea, [
+      'ochre-sand',
+      'indigo-night',
+      'blue-ocean',
+      'purple-wine',
+      'yellow-lime',
+      'tarnish',
+      'fancy-light',
+      'red-roses',
+      'pastel',
+      'sensible',
+      'ice-cube',
+      'green-mint',
+      'shades',
+      'fancy-dark',
+      'fluo',
+      'colorblind',
+      'default',
+      'pimp',
+      'intense',
+      'all',
+    ]);
   });
 });

--- a/npm/test/helpers.js
+++ b/npm/test/helpers.js
@@ -19,13 +19,6 @@ function deepApproximatelyEqual(a1, a2) {
   });
 }
 
-function rgbHexToLab(hex) {
-  return helpers.rgbToLab([
-    parseInt(hex.slice(1, 3), 16),
-    parseInt(hex.slice(3, 5), 16),
-    parseInt(hex.slice(5, 7), 16)
-  ]);
-}
 
 describe('helpers', function() {
 
@@ -55,7 +48,7 @@ describe('helpers', function() {
     ];
 
     var output = helpers
-      .diffSort(distances.get('euclidean'), colors.map(rgbHexToLab))
+      .diffSort(distances.get('euclidean'), colors.map(helpers.rgbHexToLab))
       .map(helpers.labToRgbHex);
 
     assert.deepEqual(output, sortedColors);

--- a/npm/test/index.js
+++ b/npm/test/index.js
@@ -94,5 +94,26 @@ describe('iwanthue', function() {
     assert.includeMembers(palette4, ['#9dd7b4']);
   });
 
+  it('should be possible to pass originalColorsToExpand to expand palette without a colorSpace.', function() {
+
+    var palette = iwanthue(3, {originalColorsToExpand: ['#60a862', '#c15ca5'], seed: 123});
+    assert.sameMembers(palette, ['#60a862', '#c15ca5', '#be6d40']);
+
+    var palette3 = iwanthue(5, {originalColorsToExpand: ['#94b3b9', '#9552b3', '#98bf5a', '#c7614e'], seed: 123});
+    assert.includeMembers(palette3, ['#94b3b9', '#9552b3', '#98bf5a', '#c7614e', '#4f4142']);
+
+    var palette2 = iwanthue(8, {originalColorsToExpand: [
+      '#6785ce', '#ca576b', '#5eab65', '#b55eb2',
+      '#aa9b41', '#c86a38', '#6596cd'], seed: 123});
+    // original colors are still there
+    assert.includeMembers(palette2, ['#6785ce', '#ca576b', '#5eab65', '#b55eb2', '#aa9b41', '#c86a38', '#6596cd']);
+    // the new one has been added
+    assert.includeMembers(palette2, ['#49b2a0']);
+    var palette4 = iwanthue(5, {
+      originalColorsToExpand: ['#e6b8c4', '#98d4e4', '#e1c4aa', '#bfbee0'],
+      seed: 123
+    });
+    assert.includeMembers(palette4, ['#9dd7b4']);
+  });
 });
 

--- a/npm/test/index.js
+++ b/npm/test/index.js
@@ -74,7 +74,7 @@ describe('iwanthue', function() {
 
     var palette = iwanthue(3, {originalColorsToExpand: ['#60a862', '#c15ca5'], seed: 123, colorSpace: 'all'});
     assert.sameMembers(palette, ['#60a862', '#c15ca5', '#986e5e']);
- 
+
 
     var palette3 = iwanthue(5, {originalColorsToExpand: ['#94b3b9', '#9552b3', '#98bf5a', '#c7614e'], seed: 123, colorSpace: 'all'});
     assert.includeMembers(palette3, ['#94b3b9', '#9552b3', '#98bf5a', '#c7614e', '#4f4142']);
@@ -86,8 +86,12 @@ describe('iwanthue', function() {
     assert.includeMembers(palette2, ['#6785ce', '#ca576b', '#5eab65', '#b55eb2', '#aa9b41', '#c86a38', '#6596cd']);
     // the new one has been added
     assert.includeMembers(palette2, ['#514343']);
-
-  
+    var palette4 = iwanthue(5, {
+      originalColorsToExpand: ['#e6b8c4', '#98d4e4', '#e1c4aa', '#bfbee0'],
+      colorSpace: 'fancy-light',
+      seed: 123
+    });
+    assert.includeMembers(palette4, ['#9dd7b4']);
   });
 
 });

--- a/npm/test/index.js
+++ b/npm/test/index.js
@@ -68,4 +68,27 @@ describe('iwanthue', function() {
 
     assert.sameMembers(palette, palette2);
   });
+
+
+  it('should be possible to pass originalColorsToExpand to expand palette.', function() {
+
+    var palette = iwanthue(3, {originalColorsToExpand: ['#60a862', '#c15ca5'], seed: 123, colorSpace: 'all'});
+    assert.sameMembers(palette, ['#60a862', '#c15ca5', '#986e5e']);
+ 
+
+    var palette3 = iwanthue(5, {originalColorsToExpand: ['#94b3b9', '#9552b3', '#98bf5a', '#c7614e'], seed: 123, colorSpace: 'all'});
+    assert.includeMembers(palette3, ['#94b3b9', '#9552b3', '#98bf5a', '#c7614e', '#4f4142']);
+
+    var palette2 = iwanthue(8, {originalColorsToExpand: [
+      '#6785ce', '#ca576b', '#5eab65', '#b55eb2',
+      '#aa9b41', '#c86a38', '#6596cd'], seed: 123, colorSpace: 'all'});
+    // original colors are still there
+    assert.includeMembers(palette2, ['#6785ce', '#ca576b', '#5eab65', '#b55eb2', '#aa9b41', '#c86a38', '#6596cd']);
+    // the new one has been added
+    assert.includeMembers(palette2, ['#514343']);
+
+  
+  });
+
 });
+


### PR DESCRIPTION
Add in the npm package the expand palette feature which already exist in the front-end. I used the same algorithm.
Added another feature to detect the smallest preset which contains all colors for a given palette. This is used to allow to expand a palette without knowing the original preset.

API changes: 

- added a new iwanthue settings `originalColorsToExpand`
- added a new helper  `detectSmallestCompatibleColorSpace`

